### PR TITLE
Remove channel id array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Static analysis
         run: |
           pip3 install slither-analyzer==0.10.4
-          slither --exclude solc-version,timestamp,boolean-equality,unimplemented-functions,locked-ether --filter-paths vendor/ .
+          slither --exclude solc-version,timestamp,boolean-equality,unimplemented-functions,locked-ether,immutable-states --filter-paths vendor/ .
           # Alternatively, one can use Docker:
           # WORKDIR=/share docker run --rm -v $(pwd):$WORKDIR -w $WORKDIR --entrypoint slither trailofbits/eth-security-toolbox [insert slither parameters here]
 

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -61,7 +61,7 @@ abstract contract AssetHolder {
      * @notice Address of the adjudicator contract that can call setOutcome.
      * @dev Set by the constructor.
      */
-    address public adjudicator; // solhint-disable-line immutable-states
+    address public adjudicator;
 
     /**
      * @notice The onlyAdjudicator modifier specifies functions that can only be called from the adjudicator contract.

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -61,7 +61,7 @@ abstract contract AssetHolder {
      * @notice Address of the adjudicator contract that can call setOutcome.
      * @dev Set by the constructor.
      */
-    address public immutable adjudicator;
+    address public adjudicator; // solhint-disable-line immutable-states
 
     /**
      * @notice The onlyAdjudicator modifier specifies functions that can only be called from the adjudicator contract.

--- a/contracts/Channel.sol
+++ b/contracts/Channel.sol
@@ -36,7 +36,7 @@ library Channel {
     }
 
     struct State {
-        bytes32[] channelID;
+        bytes32 channelID;
         uint64 version;
         Allocation outcome;
         bytes appData;
@@ -59,7 +59,7 @@ library Channel {
 
     struct SubAlloc {
         // ID is the channelID of the subchannel
-        bytes32[] ID; // solhint-disable-line var-name-mixedcase
+        bytes32 ID; // solhint-disable-line var-name-mixedcase
         // balances holds the total balance of the subchannel of every asset.
         uint256[] balances;
         // indexMap maps each sub-channel participant to a parent channel
@@ -125,36 +125,9 @@ library Channel {
         SubAlloc memory a,
         SubAlloc memory b
     ) internal pure {
-        require(areBytes32ArraysEqual(a.ID, b.ID), "SubAlloc: unequal ID");
+        require(a.ID == b.ID, "SubAlloc: unequal ID");
         Array.requireEqualUint256Array(a.balances, b.balances);
         Array.requireEqualUint16Array(a.indexMap, b.indexMap);
-    }
-
-    // @dev areBytes32ArraysEqual checks if two arrays of bytes32 are equal.
-    function areBytes32ArraysEqual(bytes32[] memory arr1, bytes32[] memory arr2) internal pure returns (bool) {
-        if (arr1.length != arr2.length) {
-            return false;
-        }
-        for (uint i = 0; i < arr1.length; ++i) {
-            if (arr1[i] != arr2[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @dev findBackendIndex finds out which of the channelIDs corresponds to the ethereum encoded channelID.
-     * Reverts if none of the channelIDs has a zero backend.
-     * Optimized for the common case of only one zero backend.
-     */
-    function findBackendIndex(bytes32[] memory channel, uint256[] memory backends) internal pure returns (uint64) {
-        require(channel.length == backends.length, "Array lengths mismatch");
-
-        if (backends[0] == 1) return 0;
-        if (backends.length > 1 && backends[1] == 1) return 1;
-
-        return 0;
     }
 
     /// @dev Asserts that a and b are equal.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,12 +10,6 @@ import "solidity-coverage";
 const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.28",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
-      },
-    },
   },
 };
 

--- a/test/Channel.ts
+++ b/test/Channel.ts
@@ -117,13 +117,13 @@ export class Params {
 }
 
 export class State {
-  channelID: string[];
+  channelID: string;
   version: string;
   outcome: Allocation;
   appData: string;
   isFinal: boolean;
 
-  constructor(_channelID: string[], _version: string, _outcome: Allocation, _appData: string, _isFinal: boolean) {
+  constructor(_channelID: string, _version: string, _outcome: Allocation, _appData: string, _isFinal: boolean) {
     this.channelID = _channelID;
     this.version = _version;
     this.outcome = _outcome;
@@ -144,7 +144,7 @@ export class State {
   encode() {
     const abiCoder = new ethers.AbiCoder();
     const stateType = [
-      'tuple(bytes32[] channelID, uint64 version, tuple(tuple(uint256 chainID, address ethHolder, bytes ccHolder)[] assets, uint256[] backends, uint256[][] balances, tuple(bytes32[] ID, uint256[] balances, uint16[] indexMap)[] locked) outcome, bytes appData, bool isFinal)'
+      'tuple(bytes32 channelID, uint64 version, tuple(tuple(uint256 chainID, address ethHolder, bytes ccHolder)[] assets, uint256[] backends, uint256[][] balances, tuple(bytes32 ID, uint256[] balances, uint16[] indexMap)[] locked) outcome, bytes appData, bool isFinal)'
     ];
 
     return abiCoder.encode(stateType, [{
@@ -198,11 +198,11 @@ export class Allocation {
 }
 
 export class SubAlloc {
-  ID: string[];
+  ID: string;
   balances: string[];
   indexMap: number[];
 
-  constructor(id: string[], balances: string[], indexMap: number[]) {
+  constructor(id: string, balances: string[], indexMap: number[]) {
     this.ID = id;
     this.balances = balances;
     this.indexMap = indexMap;
@@ -219,7 +219,7 @@ export class Transaction extends Channel {
   constructor(parts: Participant[], balances: BigNumberish[], challengeDuration: number, nonce: string, asset: Asset, backends: number[], app: string) {
     const params = new Params(app, challengeDuration, nonce, [parts[0], parts[1]], true);
     const outcome = new Allocation([asset], backends, [[balances[0].toString(), balances[1].toString()]], []);
-    const state = new State([params.channelID()], "0", outcome, "0x00", false);
+    const state = new State(params.channelID(), "0", outcome, "0x00", false);
     super(params, state);
     this.sigs = [];
   }


### PR DESCRIPTION
This PR extends and optimizes https://github.com/hyperledger-labs/perun-eth-contracts/pull/40 by removing the channelID array. The need for multiple channelIDs was eliminated by adding Ethereum encoding support to our other backends.